### PR TITLE
Requiring Sun Java

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+minecraft-installer (1.4) unstable; urgency=low
+
+  * Requiring the Sun JRE, as OpenJDK doesn't seem to work very well.
+
+ -- Jared R Baldridge <jrb@expunge.us>  Mon, 01 Aug 2011 15:12:03 -0700
+
 minecraft-installer (1.3) unstable; urgency=low
 
   * Updated the URL to the launcher's jar file which seems to have changed.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Vcs-Browser: http://github.com/grahamedgecombe/minecraft-installer
 
 Package: minecraft-installer
 Architecture: all
-Depends: ${misc:Depends}, openjdk-6-jre | sun-java6-jre, wget | curl, imagemagick
+Depends: ${misc:Depends}, sun-java6-jre, wget | curl, imagemagick
 Description: Minecraft
  Downloads and installs the official Minecraft client.

--- a/minecraft
+++ b/minecraft
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/bin/java -Xmx1024M -Xms512M -cp /usr/share/minecraft-installer/minecraft.jar net.minecraft.LauncherFrame
+/usr/lib/jvm/java-6-sun/bin/java -Xmx1024M -Xms512M -cp /usr/share/minecraft-installer/minecraft.jar net.minecraft.LauncherFrame


### PR DESCRIPTION
I've noticed OpenJDK doesn't work very well with Minecraft, so I've updated the installer package and launcher script to require/use sun-java6
