### PR TITLE
Drop https from debian/minecraft-installer.postinst

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+minecraft-installer (1.7~flexiondotorg1) UNRELEASED; urgency=medium
+
+  * debian/minecraft-installer.postinst: Use http to avoid certificate errors.
+
+ -- Martin Wimpress <code@flexion.org>  Tue, 13 Oct 2015 09:32:24 +0100
+
 minecraft-installer (1.6) unstable; urgency=low
 
   * Add headless server support

--- a/debian/minecraft-installer.postinst
+++ b/debian/minecraft-installer.postinst
@@ -20,7 +20,7 @@ set -e
 
 case "$1" in
     configure)
-    MINECRAFT_JAR_SRC=https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
+    MINECRAFT_JAR_SRC=http://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
     MINECRAFT_ICON_SRC=http://www.minecraft.net/favicon.png
 
     MINECRAFT_JAR_TMP=`tempfile -p minecraft -s .jar`


### PR DESCRIPTION
I recently built this in a PPA for Ubuntu and discovered that `minecraft-installer.postinst` fails due to an SSL certificate issue. As `minecraft-server-installer.postinst` already uses http I've simply reverted to http for `minecraft-installer.postinst`.