### PR TITLE
Fix broken image link by replacing; change to https

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+minecraft-installer (1.8_fix) unstable; urgency=low
+  * Change icon URL, fixing broken functionality of package
+
+   -- Ted Hart-Davis <tedster@tedster.net>  Tues, 19 Mar 2019 12:07:00 +0000
+
 minecraft-installer (1.8) unstable; urgency=low
 
   * Switch to new favicon URL

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-minecraft-installer (1.8_fix) unstable; urgency=low
+minecraft-installer (1.8~fix) unstable; urgency=low
 
   * Change icon URL, fixing broken functionality of package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
 minecraft-installer (1.8_fix) unstable; urgency=low
+
   * Change icon URL, fixing broken functionality of package
 
-   -- Ted Hart-Davis <tedster@tedster.net>  Tues, 19 Mar 2019 12:07:00 +0000
+ -- Ted Hart-Davis <tedster@tedster.net>  Tues, 19 Mar 2019 12:07:00 +0000
 
 minecraft-installer (1.8) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -4,9 +4,9 @@ Priority: extra
 Maintainer: Graham Edgecombe <graham@grahamedgecombe.com>
 Build-Depends: debhelper (>= 8)
 Standards-Version: 3.9.5
-Homepage: http://www.grahamedgecombe.com/projects/minecraft-installer
+Homepage: https://www.grahamedgecombe.com/projects/minecraft-installer
 Vcs-Git: git://github.com/grahamedgecombe/minecraft-installer.git
-Vcs-Browser: http://github.com/grahamedgecombe/minecraft-installer
+Vcs-Browser: https://github.com/grahamedgecombe/minecraft-installer
 
 Package: minecraft-installer
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: minecraft-installer
 Upstream-Contact: Graham Edgecombe <graham@grahamedgecombe.com>
 Source: https://github.com/grahamedgecombe/minecraft-installer
@@ -18,7 +18,7 @@ License: GPL-3
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/debian/minecraft-installer.postinst
+++ b/debian/minecraft-installer.postinst
@@ -14,14 +14,14 @@ set -e
 #        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
 #          <failed-install-package> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 
 case "$1" in
     configure)
-    MINECRAFT_JAR_SRC=http://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
-    MINECRAFT_ICON_SRC=http://www.minecraft.net/android-icon-192x192.png
+    MINECRAFT_JAR_SRC=https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
+    MINECRAFT_ICON_SRC=https://www.minecraft.net/android-icon-192x192.png
 
     MINECRAFT_JAR_TMP=`tempfile -p minecraft -s .jar`
     MINECRAFT_ICON_TMP=`tempfile -p favicon -s .png`

--- a/debian/minecraft-installer.postinst
+++ b/debian/minecraft-installer.postinst
@@ -21,7 +21,10 @@ set -e
 case "$1" in
     configure)
     MINECRAFT_JAR_SRC=https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
-    MINECRAFT_ICON_SRC=https://www.minecraft.net/android-icon-192x192.png
+    # MINECRAFT_ICON_SRC=https://www.minecraft.net/android-icon-192x192.png
+    # that's no longer available. I'm replacing it with another one that's...less official but still.
+    # It's impressive to me that the entire thing was tripping up on this. -TedsterTech
+    MINECRAFT_ICON_SRC=https://icons.iconarchive.com/icons/papirus-team/papirus-apps/256/minecraft-icon.png
 
     MINECRAFT_JAR_TMP=`tempfile -p minecraft -s .jar`
     MINECRAFT_ICON_TMP=`tempfile -p favicon -s .png`

--- a/debian/minecraft-installer.prerm
+++ b/debian/minecraft-installer.prerm
@@ -13,7 +13,7 @@ set -e
 #        * <deconfigured's-prerm> `deconfigure' `in-favour'
 #          <package-being-installed> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 

--- a/debian/minecraft-server-installer.postinst
+++ b/debian/minecraft-server-installer.postinst
@@ -14,13 +14,13 @@ set -e
 #        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
 #          <failed-install-package> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 
 case "$1" in
     configure)
-    MINECRAFT_BASE_SRC="http://s3.amazonaws.com/Minecraft.Download/versions"
+    MINECRAFT_BASE_SRC="https://s3.amazonaws.com/Minecraft.Download/versions"
     MINECRAFT_VERSIONS_SRC="$MINECRAFT_BASE_SRC/versions.json"
 
     MINECRAFT_JAR_TMP=`tempfile -p minecraft_server -s .jar`

--- a/debian/minecraft-server-installer.prerm
+++ b/debian/minecraft-server-installer.prerm
@@ -13,7 +13,7 @@ set -e
 #        * <deconfigured's-prerm> `deconfigure' `in-favour'
 #          <package-being-installed> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 


### PR DESCRIPTION
Hi Graham!
I've known and used your Minecraft block/item IDs site for years, and only a few hours ago realised that you'd made this.
Someone in a community around a particular Minecraft server was trying to get Minecraft running on Mint, using this package, and couldn't. I tried myself and saw that the icon you were pulling was 404ing and that broke the entire install.
So, I managed to patch that and then switched everything to HTTPS for good measure, built it myself and it works!
Thanks for all your work, and please accept this patch as a sign of my gratitude towards your efforts (: